### PR TITLE
Rename 'humid_temp' to 'hdc1000'.

### DIFF
--- a/drivers/hdc1000/Makefile
+++ b/drivers/hdc1000/Makefile
@@ -1,4 +1,4 @@
-modulename := humid_temp
+modulename := hdc1000
 
 obj-m += $(modulename).o
 

--- a/drivers/hdc1000/hdc1000.c
+++ b/drivers/hdc1000/hdc1000.c
@@ -21,7 +21,7 @@
 #include <linux/fs.h>
 #include <linux/uaccess.h>
 
-#define DRIVER_NAME "humid_temp"
+#define DRIVER_NAME "hdc1000"
 
 #define NUM_BYTE_DATA 4
 #define NUM_BYTE_TIMESTAMP 8

--- a/user/hdc1000/main.cpp
+++ b/user/hdc1000/main.cpp
@@ -20,7 +20,7 @@ struct HDC1000 {
 };
 
 std::optional<HDC1000> readFromCDev() {
-    static const std::string CHARACTER_DEVICE = "/dev/humid_temp";
+    static const std::string CHARACTER_DEVICE = "/dev/hdc1000";
     static const int READ_SIZE = 12;
 
     static const int OFFSET_TEMPERATURE = 0;


### PR DESCRIPTION
Future drivers will be named after the sensors name.

Thus, also rename this one.