### PR TITLE
Add kernel driver for APDS9301 Ambient Light Photo Sensor

### DIFF
--- a/drivers/apds9301/Makefile
+++ b/drivers/apds9301/Makefile
@@ -1,0 +1,23 @@
+modulename := apds9301
+
+obj-m += $(modulename).o
+
+
+all:
+	$(MAKE) -C $(KERNEL_SRC) M=$(PWD)
+
+modules_install:
+	$(MAKE) -C $(KERNEL_SRC) M=$(PWD) modules_install
+
+clean:
+	rm -f *.o *~ core .depend .*.cmd *.ko *.mod.c
+	rm -f Module.markers Module.symvers modules.order
+	rm -rf .tmp_versions Modules.symvers
+
+deploy: all
+	scp $(modulename).ko "$(DEPLOYSSH):$(DEPLOYSSHPATH)/$(modulename).ko"
+	ssh $(DEPLOYSSH) "rmmod $(modulename)";
+	ssh $(DEPLOYSSH) "insmod $(DEPLOYSSHPATH)/$(modulename).ko";
+
+
+.PHONY: all clean deploy

--- a/drivers/apds9301/apds9301.c
+++ b/drivers/apds9301/apds9301.c
@@ -1,5 +1,5 @@
 /*
- * Terasic DE1-SoC Sensor Driver for HDC1000 Temperature/Humidity Sensor
+ * Terasic DE1-SoC Sensor Driver for APDS9301 Ambient Light Photo Sensor
  *
  * Copyright (C) 2019 Michael Wurm <michael.wurm@students.fh-hagenberg.at>
  *
@@ -21,7 +21,7 @@
 #include <linux/fs.h>
 #include <linux/uaccess.h>
 
-#define DRIVER_NAME "hdc1000"
+#define DRIVER_NAME "apds9301"
 
 #define NUM_BYTE_DATA 4
 #define NUM_BYTE_TIMESTAMP 8
@@ -32,7 +32,7 @@
 #define MEM_OFFSET_TIMESTAMP_LOW (0x4)
 #define MEM_OFFSET_TIMESTAMP_HIGH (0x8)
 
-struct humid_temp
+struct data
 {
   void *regs;
   char buffer[BUF_SIZE];
@@ -43,11 +43,11 @@ struct humid_temp
 /*
  * @brief This function gets executed on fread.
  */
-static int humid_temp_read(struct file *filep, char *buf, size_t count,
-                           loff_t *offp)
+static int dev_read(struct file *filep, char *buf, size_t count,
+                    loff_t *offp)
 {
-  struct humid_temp *dev = container_of(filep->private_data,
-                                        struct humid_temp, misc);
+  struct data *dev = container_of(filep->private_data,
+                                  struct data, misc);
   unsigned int rdata;
 
   /* check out of bound access */
@@ -86,13 +86,13 @@ static int humid_temp_read(struct file *filep, char *buf, size_t count,
   return count;
 }
 
-static const struct file_operations humid_temp_fops = {
+static const struct file_operations dev_fops = {
     .owner = THIS_MODULE,
-    .read = humid_temp_read};
+    .read = dev_read};
 
 static int dev_probe(struct platform_device *pdev)
 {
-  struct humid_temp *dev;
+  struct data *dev;
   struct resource *io;
   int retval;
 
@@ -109,7 +109,7 @@ static int dev_probe(struct platform_device *pdev)
   dev->size = io->end - io->start + 1;
   dev->misc.name = DRIVER_NAME;
   dev->misc.minor = MISC_DYNAMIC_MINOR;
-  dev->misc.fops = &humid_temp_fops;
+  dev->misc.fops = &dev_fops;
   dev->misc.parent = &pdev->dev;
   retval = misc_register(&dev->misc);
   if (retval)
@@ -118,14 +118,14 @@ static int dev_probe(struct platform_device *pdev)
     return retval;
   }
 
-  dev_info(&pdev->dev, "HDC1000 Humidity/Temperature driver loaded!");
+  dev_info(&pdev->dev, "APDS9301 Ambient Light Photo Sensor driver loaded!");
 
   return 0;
 }
 
 static int dev_remove(struct platform_device *pdev)
 {
-  struct humid_temp *dev = platform_get_drvdata(pdev);
+  struct data *dev = platform_get_drvdata(pdev);
 
   misc_deregister(&dev->misc);
   platform_set_drvdata(pdev, NULL);
@@ -133,26 +133,26 @@ static int dev_remove(struct platform_device *pdev)
   return 0;
 }
 
-static const struct of_device_id humid_temp_of_match[] = {
+static const struct of_device_id dev_of_match[] = {
     {
-        .compatible = "goe,humid_temp-1.0",
+        .compatible = "goe,apds9301-1.0",
     },
     {},
 };
-MODULE_DEVICE_TABLE(of, humid_temp_of_match);
+MODULE_DEVICE_TABLE(of, dev_of_match);
 
-static struct platform_driver humid_temp_driver = {
+static struct platform_driver dev_driver = {
     .driver = {
         .name = DRIVER_NAME,
         .owner = THIS_MODULE,
-        .of_match_table = of_match_ptr(humid_temp_of_match),
+        .of_match_table = of_match_ptr(dev_of_match),
     },
     .probe = dev_probe,
     .remove = dev_remove,
 };
 
-module_platform_driver(humid_temp_driver);
+module_platform_driver(dev_driver);
 
 MODULE_AUTHOR("M.Wurm");
-MODULE_DESCRIPTION("Altera/Terasic HDC1000 Humidity/Temperature driver");
+MODULE_DESCRIPTION("Altera/Terasic APDS9301 Ambient Light Photo Sensor driver");
 MODULE_LICENSE("GPL v2");

--- a/drivers/apds9301/apds9301.c
+++ b/drivers/apds9301/apds9301.c
@@ -23,7 +23,7 @@
 
 #define DRIVER_NAME "apds9301"
 
-#define NUM_BYTE_DATA 4
+#define NUM_BYTE_DATA 2
 #define NUM_BYTE_TIMESTAMP 8
 
 #define BUF_SIZE (NUM_BYTE_DATA + NUM_BYTE_TIMESTAMP)
@@ -59,23 +59,21 @@ static int dev_read(struct file *filep, char *buf, size_t count,
     count = BUF_SIZE - *offp;
 
   /* read data from FPGA and store into kernel space buffer */
-  rdata = ioread32(dev->regs + MEM_OFFSET_DATA);
+  rdata = ioread16(dev->regs + MEM_OFFSET_DATA);
   dev->buffer[0] = ((rdata & 0x000000FF) >> 0);
   dev->buffer[1] = ((rdata & 0x0000FF00) >> 8);
-  dev->buffer[2] = ((rdata & 0x00FF0000) >> 16);
-  dev->buffer[3] = ((rdata & 0xFF000000) >> 24);
 
   rdata = ioread32(dev->regs + MEM_OFFSET_TIMESTAMP_LOW);
-  dev->buffer[4] = ((rdata & 0x000000FF) >> 0);
-  dev->buffer[5] = ((rdata & 0x0000FF00) >> 8);
-  dev->buffer[6] = ((rdata & 0x00FF0000) >> 16);
-  dev->buffer[7] = ((rdata & 0xFF000000) >> 24);
+  dev->buffer[2] = ((rdata & 0x000000FF) >> 0);
+  dev->buffer[3] = ((rdata & 0x0000FF00) >> 8);
+  dev->buffer[4] = ((rdata & 0x00FF0000) >> 16);
+  dev->buffer[5] = ((rdata & 0xFF000000) >> 24);
 
   rdata = ioread32(dev->regs + MEM_OFFSET_TIMESTAMP_HIGH);
-  dev->buffer[8] = ((rdata & 0x000000FF) >> 0);
-  dev->buffer[9] = ((rdata & 0x0000FF00) >> 8);
-  dev->buffer[10] = ((rdata & 0x00FF0000) >> 16);
-  dev->buffer[11] = ((rdata & 0xFF000000) >> 24);
+  dev->buffer[6] = ((rdata & 0x000000FF) >> 0);
+  dev->buffer[7] = ((rdata & 0x0000FF00) >> 8);
+  dev->buffer[8] = ((rdata & 0x00FF0000) >> 16);
+  dev->buffer[9] = ((rdata & 0xFF000000) >> 24);
 
   /* copy data from kernel space buffer into user space */
   if (count > 0)

--- a/drivers/apds9301/apds9301.c
+++ b/drivers/apds9301/apds9301.c
@@ -37,7 +37,7 @@ typedef struct
   uint32_t timestamp_lo;
   uint32_t timestamp_hi;
   uint16_t value;
-} buffer_t;
+} __attribute__((packed)) buffer_t;
 
 struct data
 {

--- a/drivers/apds9301/apds9301.c
+++ b/drivers/apds9301/apds9301.c
@@ -42,7 +42,7 @@ typedef struct
 struct data
 {
   void *regs;
-  char buffer[BUF_SIZE];
+  buffer_t buffer;
   int size;
   struct miscdevice misc;
 };

--- a/drivers/apds9301/apds9301.c
+++ b/drivers/apds9301/apds9301.c
@@ -56,9 +56,8 @@ static int dev_read(struct file *filep, char *buf, size_t count,
   struct data *dev = container_of(filep->private_data,
                                   struct data, misc);
   unsigned int rdata;
-  buffer_t tmpBuf;
 
-  if (BUF_SIZE != sizeof(tmpBuf))
+  if (BUF_SIZE != sizeof(dev->buffer))
   {
     printk(KERN_ERR "Data struct buffer_t is not allocated as expected.\n");
     BUG();
@@ -75,10 +74,10 @@ static int dev_read(struct file *filep, char *buf, size_t count,
 
   /* read data from FPGA and store into kernel space buffer */
   rdata = ioread16(dev->regs + MEM_OFFSET_DATA);
-  tmpBuf.value = (rdata & 0x0000FFFF);
+  dev->buffer.value = (rdata & 0x0000FFFF);
 
-  tmpBuf.timestamp_lo = ioread32(dev->regs + MEM_OFFSET_TIMESTAMP_LOW);
-  tmpBuf.timestamp_hi = ioread32(dev->regs + MEM_OFFSET_TIMESTAMP_HIGH);
+  dev->buffer.timestamp_lo = ioread32(dev->regs + MEM_OFFSET_TIMESTAMP_LOW);
+  dev->buffer.timestamp_hi = ioread32(dev->regs + MEM_OFFSET_TIMESTAMP_HIGH);
 
   /* copy data from kernel space buffer into user space */
   if (count > 0)


### PR DESCRIPTION
Add a kernel driver module that interacts with an FPGA core, which provides data from the APDS9301 Ambient Light Photo Sensor.
