### PR TITLE
Add kernel driver for MPU9250 Gyroscope/Accelerometer/Magnetometer Sensor.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ hdl/scripts/*
 !hdl/scripts/*.sh
 
 drivers/**/*.o
+drivers/**/*.d
 drivers/**/*.cmd
 drivers/**/*.o.cmd
 drivers/**/*.symvers

--- a/drivers/mpu9250/Makefile
+++ b/drivers/mpu9250/Makefile
@@ -1,0 +1,23 @@
+modulename := mpu9250
+
+obj-m += $(modulename).o
+
+
+all:
+	$(MAKE) -C $(KERNEL_SRC) M=$(PWD)
+
+modules_install:
+	$(MAKE) -C $(KERNEL_SRC) M=$(PWD) modules_install
+
+clean:
+	rm -f *.o *~ core .depend .*.cmd *.ko *.mod.c
+	rm -f Module.markers Module.symvers modules.order
+	rm -rf .tmp_versions Modules.symvers
+
+deploy: all
+	scp $(modulename).ko "$(DEPLOYSSH):$(DEPLOYSSHPATH)/$(modulename).ko"
+	ssh $(DEPLOYSSH) "rmmod $(modulename)";
+	ssh $(DEPLOYSSH) "insmod $(DEPLOYSSHPATH)/$(modulename).ko";
+
+
+.PHONY: all clean deploy

--- a/drivers/mpu9250/mpu9250.c
+++ b/drivers/mpu9250/mpu9250.c
@@ -30,9 +30,9 @@
 #define MEM_OFFSET_DATA_GYRO_X (0x0)
 #define MEM_OFFSET_DATA_GYRO_Y (0x4)
 #define MEM_OFFSET_DATA_GYRO_Z (0x8)
-#define MEM_OFFSET_DATA_ACCEL_X (0xC)
-#define MEM_OFFSET_DATA_ACCEL_Y (0x10)
-#define MEM_OFFSET_DATA_ACCEL_Z (0x14)
+#define MEM_OFFSET_DATA_ACC_X (0xC)
+#define MEM_OFFSET_DATA_ACC_Y (0x10)
+#define MEM_OFFSET_DATA_ACC_Z (0x14)
 #define MEM_OFFSET_DATA_MAG_X (0x18)
 #define MEM_OFFSET_DATA_MAG_Y (0x1C)
 #define MEM_OFFSET_DATA_MAG_Z (0x20)
@@ -46,9 +46,9 @@ typedef struct
   uint16_t gyro_x;
   uint16_t gyro_y;
   uint16_t gyro_z;
-  uint16_t accel_x;
-  uint16_t accel_y;
-  uint16_t accel_z;
+  uint16_t acc_x;
+  uint16_t acc_y;
+  uint16_t acc_z;
   uint16_t mag_x;
   uint16_t mag_y;
   uint16_t mag_z;
@@ -91,12 +91,12 @@ static int dev_read(struct file *filep, char *buf, size_t count,
   rdata = ioread16(dev->regs + MEM_OFFSET_DATA_GYRO_Z);
   tmpBuf.gyro_z = (rdata & 0x0000FFFF);
 
-  rdata = ioread16(dev->regs + MEM_OFFSET_DATA_ACCEL_X);
-  tmpBuf.accel_x = (rdata & 0x0000FFFF);
-  rdata = ioread16(dev->regs + MEM_OFFSET_DATA_ACCEL_Y);
-  tmpBuf.accel_y = (rdata & 0x0000FFFF);
-  rdata = ioread16(dev->regs + MEM_OFFSET_DATA_ACCEL_Z);
-  (tmpBuf.accel_z = (rdata & 0x0000FFFF));
+  rdata = ioread16(dev->regs + MEM_OFFSET_DATA_ACC_X);
+  tmpBuf.acc_x = (rdata & 0x0000FFFF);
+  rdata = ioread16(dev->regs + MEM_OFFSET_DATA_ACC_Y);
+  tmpBuf.acc_y = (rdata & 0x0000FFFF);
+  rdata = ioread16(dev->regs + MEM_OFFSET_DATA_ACC_Z);
+  (tmpBuf.acc_z = (rdata & 0x0000FFFF));
 
   rdata = ioread16(dev->regs + MEM_OFFSET_DATA_MAG_X);
   tmpBuf.mag_x = (rdata & 0x0000FFFF);

--- a/drivers/mpu9250/mpu9250.c
+++ b/drivers/mpu9250/mpu9250.c
@@ -32,6 +32,19 @@
 #define MEM_OFFSET_TIMESTAMP_LOW (0x4)
 #define MEM_OFFSET_TIMESTAMP_HIGH (0x8)
 
+// Vorschlag zur Änderung:
+// 0 [15:00]: Gyro X
+// 1 [15:00]: Gyro Y
+// 2 [15:00]: Gyro Z
+// 3 [15:00]: Beschleunigung X
+// 4 [15:00]: Beschleunigung Y
+// 5 [15:00]: Beschleunigung Z
+// 6 [15:00]: Magnetometer X
+// 7 [15:00]: Magnetometer Y
+// 8 [15:00]: Magnetometer Z
+// 9 [31:00]: Timestamp[31:0]
+// 10 [31:00]: Timestamp[64:32]
+
 struct data
 {
   void *regs;

--- a/drivers/mpu9250/mpu9250.c
+++ b/drivers/mpu9250/mpu9250.c
@@ -39,10 +39,18 @@
 #define MEM_OFFSET_TIMESTAMP_LOW (0x24)
 #define MEM_OFFSET_TIMESTAMP_HIGH (0x28)
 
+struct buffer
+{
+  u32 timestamp;
+  u32 timestamp;
+  u16 data;
+  ...
+};
+
 struct data
 {
   void *regs;
-  char buffer[BUF_SIZE];
+  struct buffer;
   int size;
   struct miscdevice misc;
 };
@@ -56,6 +64,8 @@ static int dev_read(struct file *filep, char *buf, size_t count,
   struct data *dev = container_of(filep->private_data,
                                   struct data, misc);
   unsigned int rdata;
+
+  assert(BUF_SIZE == sizeof(buffer));
 
   /* check out of bound access */
   if ((*offp < 0) || (*offp >= BUF_SIZE))
@@ -110,7 +120,7 @@ static int dev_read(struct file *filep, char *buf, size_t count,
 
   /* copy data from kernel space buffer into user space */
   if (count > 0)
-    count = count - copy_to_user(buf, dev->buffer + *offp, count);
+    count = count - copy_to_user(buf, (char *)dev->buffer + *offp, count);
 
   *offp += count;
 

--- a/drivers/mpu9250/mpu9250.c
+++ b/drivers/mpu9250/mpu9250.c
@@ -57,7 +57,7 @@ typedef struct
 struct data
 {
   void *regs;
-  struct buffer;
+  buffer_t buffer;
   int size;
   struct miscdevice misc;
 };
@@ -73,7 +73,12 @@ static int dev_read(struct file *filep, char *buf, size_t count,
   unsigned int rdata;
   buffer_t tmpBuf;
 
-  assert(BUF_SIZE == sizeof(tmpBuf));
+  if (BUF_SIZE != sizeof(tmpBuf))
+  {
+    printk(KERN_ERR "Data struct buffer_t is not allocated as expected.\n");
+    BUG();
+    return -ENOEXEC;
+  }
 
   /* check out of bound access */
   if ((*offp < 0) || (*offp >= BUF_SIZE))
@@ -125,7 +130,7 @@ static int dev_read(struct file *filep, char *buf, size_t count,
 
   /* copy data from kernel space buffer into user space */
   if (count > 0)
-    count = count - copy_to_user(buf, (char *)dev->buffer + *offp, count);
+    count = count - copy_to_user(buf, (char *)&dev->buffer + *offp, count);
 
   *offp += count;
 

--- a/drivers/mpu9250/mpu9250.c
+++ b/drivers/mpu9250/mpu9250.c
@@ -1,0 +1,156 @@
+/*
+ * Terasic DE1-SoC Sensor Driver for APDS9301 Ambient Light Photo Sensor
+ *
+ * Copyright (C) 2019 Michael Wurm <michael.wurm@students.fh-hagenberg.at>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include <linux/module.h>
+#include <linux/platform_device.h>
+#include <linux/of.h>
+#include <linux/io.h>
+#include <linux/miscdevice.h>
+#include <linux/fs.h>
+#include <linux/uaccess.h>
+
+#define DRIVER_NAME "apds9301"
+
+#define NUM_BYTE_DATA 2
+#define NUM_BYTE_TIMESTAMP 8
+
+#define BUF_SIZE (NUM_BYTE_DATA + NUM_BYTE_TIMESTAMP)
+
+#define MEM_OFFSET_DATA (0x0)
+#define MEM_OFFSET_TIMESTAMP_LOW (0x4)
+#define MEM_OFFSET_TIMESTAMP_HIGH (0x8)
+
+struct data
+{
+  void *regs;
+  char buffer[BUF_SIZE];
+  int size;
+  struct miscdevice misc;
+};
+
+/*
+ * @brief This function gets executed on fread.
+ */
+static int dev_read(struct file *filep, char *buf, size_t count,
+                    loff_t *offp)
+{
+  struct data *dev = container_of(filep->private_data,
+                                  struct data, misc);
+  unsigned int rdata;
+
+  /* check out of bound access */
+  if ((*offp < 0) || (*offp >= BUF_SIZE))
+    return 0;
+
+  /* limit number of readable bytes to maximum which is still possible */
+  if ((*offp + count) > BUF_SIZE)
+    count = BUF_SIZE - *offp;
+
+  /* read data from FPGA and store into kernel space buffer */
+  rdata = ioread16(dev->regs + MEM_OFFSET_DATA);
+  dev->buffer[0] = ((rdata & 0x000000FF) >> 0);
+  dev->buffer[1] = ((rdata & 0x0000FF00) >> 8);
+
+  rdata = ioread32(dev->regs + MEM_OFFSET_TIMESTAMP_LOW);
+  dev->buffer[2] = ((rdata & 0x000000FF) >> 0);
+  dev->buffer[3] = ((rdata & 0x0000FF00) >> 8);
+  dev->buffer[4] = ((rdata & 0x00FF0000) >> 16);
+  dev->buffer[5] = ((rdata & 0xFF000000) >> 24);
+
+  rdata = ioread32(dev->regs + MEM_OFFSET_TIMESTAMP_HIGH);
+  dev->buffer[6] = ((rdata & 0x000000FF) >> 0);
+  dev->buffer[7] = ((rdata & 0x0000FF00) >> 8);
+  dev->buffer[8] = ((rdata & 0x00FF0000) >> 16);
+  dev->buffer[9] = ((rdata & 0xFF000000) >> 24);
+
+  /* copy data from kernel space buffer into user space */
+  if (count > 0)
+    count = count - copy_to_user(buf, dev->buffer + *offp, count);
+
+  *offp += count;
+
+  return count;
+}
+
+static const struct file_operations dev_fops = {
+    .owner = THIS_MODULE,
+    .read = dev_read};
+
+static int dev_probe(struct platform_device *pdev)
+{
+  struct data *dev;
+  struct resource *io;
+  int retval;
+
+  dev = devm_kzalloc(&pdev->dev, sizeof(*dev), GFP_KERNEL);
+  if (dev == NULL)
+    return -ENOMEM;
+  platform_set_drvdata(pdev, dev);
+
+  io = platform_get_resource(pdev, IORESOURCE_MEM, 0);
+  dev->regs = devm_ioremap_resource(&pdev->dev, io);
+  if (IS_ERR(dev->regs))
+    return PTR_ERR(dev->regs);
+
+  dev->size = io->end - io->start + 1;
+  dev->misc.name = DRIVER_NAME;
+  dev->misc.minor = MISC_DYNAMIC_MINOR;
+  dev->misc.fops = &dev_fops;
+  dev->misc.parent = &pdev->dev;
+  retval = misc_register(&dev->misc);
+  if (retval)
+  {
+    dev_err(&pdev->dev, "Register misc device failed!\n");
+    return retval;
+  }
+
+  dev_info(&pdev->dev, "APDS9301 Ambient Light Photo Sensor driver loaded!");
+
+  return 0;
+}
+
+static int dev_remove(struct platform_device *pdev)
+{
+  struct data *dev = platform_get_drvdata(pdev);
+
+  misc_deregister(&dev->misc);
+  platform_set_drvdata(pdev, NULL);
+
+  return 0;
+}
+
+static const struct of_device_id dev_of_match[] = {
+    {
+        .compatible = "goe,apds9301-1.0",
+    },
+    {},
+};
+MODULE_DEVICE_TABLE(of, dev_of_match);
+
+static struct platform_driver dev_driver = {
+    .driver = {
+        .name = DRIVER_NAME,
+        .owner = THIS_MODULE,
+        .of_match_table = of_match_ptr(dev_of_match),
+    },
+    .probe = dev_probe,
+    .remove = dev_remove,
+};
+
+module_platform_driver(dev_driver);
+
+MODULE_AUTHOR("M.Wurm");
+MODULE_DESCRIPTION("Altera/Terasic APDS9301 Ambient Light Photo Sensor driver");
+MODULE_LICENSE("GPL v2");

--- a/drivers/mpu9250/mpu9250.c
+++ b/drivers/mpu9250/mpu9250.c
@@ -23,27 +23,21 @@
 
 #define DRIVER_NAME "mpu9250"
 
-#define NUM_BYTE_DATA 2
+#define NUM_BYTE_DATA (2 * 3 * 3)
 #define NUM_BYTE_TIMESTAMP 8
-
 #define BUF_SIZE (NUM_BYTE_DATA + NUM_BYTE_TIMESTAMP)
 
-#define MEM_OFFSET_DATA (0x0)
-#define MEM_OFFSET_TIMESTAMP_LOW (0x4)
-#define MEM_OFFSET_TIMESTAMP_HIGH (0x8)
-
-// Vorschlag zur Änderung:
-// 0 [15:00]: Gyro X
-// 1 [15:00]: Gyro Y
-// 2 [15:00]: Gyro Z
-// 3 [15:00]: Beschleunigung X
-// 4 [15:00]: Beschleunigung Y
-// 5 [15:00]: Beschleunigung Z
-// 6 [15:00]: Magnetometer X
-// 7 [15:00]: Magnetometer Y
-// 8 [15:00]: Magnetometer Z
-// 9 [31:00]: Timestamp[31:0]
-// 10 [31:00]: Timestamp[64:32]
+#define MEM_OFFSET_DATA_GYRO_X (0x0)
+#define MEM_OFFSET_DATA_GYRO_Y (0x4)
+#define MEM_OFFSET_DATA_GYRO_Z (0x8)
+#define MEM_OFFSET_DATA_ACCEL_X (0xC)
+#define MEM_OFFSET_DATA_ACCEL_Y (0x10)
+#define MEM_OFFSET_DATA_ACCEL_Z (0x14)
+#define MEM_OFFSET_DATA_MAG_X (0x18)
+#define MEM_OFFSET_DATA_MAG_Y (0x1C)
+#define MEM_OFFSET_DATA_MAG_Z (0x20)
+#define MEM_OFFSET_TIMESTAMP_LOW (0x24)
+#define MEM_OFFSET_TIMESTAMP_HIGH (0x28)
 
 struct data
 {

--- a/drivers/mpu9250/mpu9250.c
+++ b/drivers/mpu9250/mpu9250.c
@@ -1,5 +1,5 @@
 /*
- * Terasic DE1-SoC Sensor Driver for APDS9301 Ambient Light Photo Sensor
+ * Terasic DE1-SoC Sensor Driver for MPU9250 Gyroscope/Accelerometer/Magnetometer Sensor
  *
  * Copyright (C) 2019 Michael Wurm <michael.wurm@students.fh-hagenberg.at>
  *
@@ -21,7 +21,7 @@
 #include <linux/fs.h>
 #include <linux/uaccess.h>
 
-#define DRIVER_NAME "apds9301"
+#define DRIVER_NAME "mpu9250"
 
 #define NUM_BYTE_DATA 2
 #define NUM_BYTE_TIMESTAMP 8
@@ -116,7 +116,7 @@ static int dev_probe(struct platform_device *pdev)
     return retval;
   }
 
-  dev_info(&pdev->dev, "APDS9301 Ambient Light Photo Sensor driver loaded!");
+  dev_info(&pdev->dev, "MPU9250 Gyroscope/Accelerometer/Magnetometer Sensor driver loaded!");
 
   return 0;
 }
@@ -133,7 +133,7 @@ static int dev_remove(struct platform_device *pdev)
 
 static const struct of_device_id dev_of_match[] = {
     {
-        .compatible = "goe,apds9301-1.0",
+        .compatible = "goe,mpu9250-1.0",
     },
     {},
 };
@@ -152,5 +152,5 @@ static struct platform_driver dev_driver = {
 module_platform_driver(dev_driver);
 
 MODULE_AUTHOR("M.Wurm");
-MODULE_DESCRIPTION("Altera/Terasic APDS9301 Ambient Light Photo Sensor driver");
+MODULE_DESCRIPTION("Altera/Terasic MPU9250 Gyroscope/Accelerometer/Magnetometer Sensor driver");
 MODULE_LICENSE("GPL v2");

--- a/drivers/mpu9250/mpu9250.c
+++ b/drivers/mpu9250/mpu9250.c
@@ -108,6 +108,21 @@ static int dev_read(struct file *filep, char *buf, size_t count,
   tmpBuf.timestamp_lo = ioread32(dev->regs + MEM_OFFSET_TIMESTAMP_LOW);
   tmpBuf.timestamp_hi = ioread32(dev->regs + MEM_OFFSET_TIMESTAMP_HIGH);
 
+  /* ------ TESTING ONLY --------------------------------------------------------- */
+  /* PROVIDE DUMMY DATA */
+  tmpBuf.gyro_x = 0x1111;
+  tmpBuf.gyro_y = 0x2222;
+  tmpBuf.gyro_z = 0x3333;
+  tmpBuf.acc_x = 0x4444;
+  tmpBuf.acc_y = 0x5555;
+  tmpBuf.acc_z = 0x6666;
+  tmpBuf.mag_x = 0x7777;
+  tmpBuf.mag_y = 0x8888;
+  tmpBuf.mag_z = 0x9999;
+  tmpBuf.timestamp_lo = 0x47001100;
+  tmpBuf.timestamp_hi = 0x48001200;
+  /* ------ TESTING ONLY --------------------------------------------------------- */
+
   /* copy data from kernel space buffer into user space */
   if (count > 0)
     count = count - copy_to_user(buf, (char *)dev->buffer + *offp, count);

--- a/drivers/mpu9250/mpu9250.c
+++ b/drivers/mpu9250/mpu9250.c
@@ -52,7 +52,7 @@ typedef struct
   uint16_t mag_x;
   uint16_t mag_y;
   uint16_t mag_z;
-} buffer_t;
+} __attribute__((packed)) buffer_t;
 
 struct data
 {

--- a/drivers/mpu9250/mpu9250.c
+++ b/drivers/mpu9250/mpu9250.c
@@ -71,9 +71,8 @@ static int dev_read(struct file *filep, char *buf, size_t count,
   struct data *dev = container_of(filep->private_data,
                                   struct data, misc);
   unsigned int rdata;
-  buffer_t tmpBuf;
 
-  if (BUF_SIZE != sizeof(tmpBuf))
+  if (BUF_SIZE != sizeof(dev->buffer))
   {
     printk(KERN_ERR "Data struct buffer_t is not allocated as expected.\n");
     BUG();
@@ -90,42 +89,42 @@ static int dev_read(struct file *filep, char *buf, size_t count,
 
   /* read data from FPGA and store into kernel space buffer */
   rdata = ioread16(dev->regs + MEM_OFFSET_DATA_GYRO_X);
-  tmpBuf.gyro_x = (rdata & 0x0000FFFF);
+  dev->buffer.gyro_x = (rdata & 0x0000FFFF);
   rdata = ioread16(dev->regs + MEM_OFFSET_DATA_GYRO_Y);
-  tmpBuf.gyro_y = (rdata & 0x0000FFFF);
+  dev->buffer.gyro_y = (rdata & 0x0000FFFF);
   rdata = ioread16(dev->regs + MEM_OFFSET_DATA_GYRO_Z);
-  tmpBuf.gyro_z = (rdata & 0x0000FFFF);
+  dev->buffer.gyro_z = (rdata & 0x0000FFFF);
 
   rdata = ioread16(dev->regs + MEM_OFFSET_DATA_ACC_X);
-  tmpBuf.acc_x = (rdata & 0x0000FFFF);
+  dev->buffer.acc_x = (rdata & 0x0000FFFF);
   rdata = ioread16(dev->regs + MEM_OFFSET_DATA_ACC_Y);
-  tmpBuf.acc_y = (rdata & 0x0000FFFF);
+  dev->buffer.acc_y = (rdata & 0x0000FFFF);
   rdata = ioread16(dev->regs + MEM_OFFSET_DATA_ACC_Z);
-  (tmpBuf.acc_z = (rdata & 0x0000FFFF));
+  (dev->buffer.acc_z = (rdata & 0x0000FFFF));
 
   rdata = ioread16(dev->regs + MEM_OFFSET_DATA_MAG_X);
-  tmpBuf.mag_x = (rdata & 0x0000FFFF);
+  dev->buffer.mag_x = (rdata & 0x0000FFFF);
   rdata = ioread16(dev->regs + MEM_OFFSET_DATA_MAG_Y);
-  tmpBuf.mag_y = (rdata & 0x0000FFFF);
+  dev->buffer.mag_y = (rdata & 0x0000FFFF);
   rdata = ioread16(dev->regs + MEM_OFFSET_DATA_MAG_Z);
-  tmpBuf.mag_z = (rdata & 0x0000FFFF);
+  dev->buffer.mag_z = (rdata & 0x0000FFFF);
 
-  tmpBuf.timestamp_lo = ioread32(dev->regs + MEM_OFFSET_TIMESTAMP_LOW);
-  tmpBuf.timestamp_hi = ioread32(dev->regs + MEM_OFFSET_TIMESTAMP_HIGH);
+  dev->buffer.timestamp_lo = ioread32(dev->regs + MEM_OFFSET_TIMESTAMP_LOW);
+  dev->buffer.timestamp_hi = ioread32(dev->regs + MEM_OFFSET_TIMESTAMP_HIGH);
 
   /* ------ TESTING ONLY --------------------------------------------------------- */
   /* PROVIDE DUMMY DATA */
-  tmpBuf.gyro_x = 0x1111;
-  tmpBuf.gyro_y = 0x2222;
-  tmpBuf.gyro_z = 0x3333;
-  tmpBuf.acc_x = 0x4444;
-  tmpBuf.acc_y = 0x5555;
-  tmpBuf.acc_z = 0x6666;
-  tmpBuf.mag_x = 0x7777;
-  tmpBuf.mag_y = 0x8888;
-  tmpBuf.mag_z = 0x9999;
-  tmpBuf.timestamp_lo = 0x47001100;
-  tmpBuf.timestamp_hi = 0x48001200;
+  dev->buffer.gyro_x = 0x1111;
+  dev->buffer.gyro_y = 0x2222;
+  dev->buffer.gyro_z = 0x3333;
+  dev->buffer.acc_x = 0x4444;
+  dev->buffer.acc_y = 0x5555;
+  dev->buffer.acc_z = 0x6666;
+  dev->buffer.mag_x = 0x7777;
+  dev->buffer.mag_y = 0x8888;
+  dev->buffer.mag_z = 0x9999;
+  dev->buffer.timestamp_lo = 0x47001100;
+  dev->buffer.timestamp_hi = 0x48001200;
   /* ------ TESTING ONLY --------------------------------------------------------- */
 
   /* copy data from kernel space buffer into user space */

--- a/drivers/mpu9250/mpu9250.c
+++ b/drivers/mpu9250/mpu9250.c
@@ -66,21 +66,47 @@ static int dev_read(struct file *filep, char *buf, size_t count,
     count = BUF_SIZE - *offp;
 
   /* read data from FPGA and store into kernel space buffer */
-  rdata = ioread16(dev->regs + MEM_OFFSET_DATA);
+  rdata = ioread16(dev->regs + MEM_OFFSET_DATA_GYRO_X);
   dev->buffer[0] = ((rdata & 0x000000FF) >> 0);
   dev->buffer[1] = ((rdata & 0x0000FF00) >> 8);
-
-  rdata = ioread32(dev->regs + MEM_OFFSET_TIMESTAMP_LOW);
+  rdata = ioread16(dev->regs + MEM_OFFSET_DATA_GYRO_Y);
   dev->buffer[2] = ((rdata & 0x000000FF) >> 0);
   dev->buffer[3] = ((rdata & 0x0000FF00) >> 8);
-  dev->buffer[4] = ((rdata & 0x00FF0000) >> 16);
-  dev->buffer[5] = ((rdata & 0xFF000000) >> 24);
+  rdata = ioread16(dev->regs + MEM_OFFSET_DATA_GYRO_Z);
+  dev->buffer[4] = ((rdata & 0x000000FF) >> 0);
+  dev->buffer[5] = ((rdata & 0x0000FF00) >> 8);
 
-  rdata = ioread32(dev->regs + MEM_OFFSET_TIMESTAMP_HIGH);
+  rdata = ioread16(dev->regs + MEM_OFFSET_DATA_ACCEL_X);
   dev->buffer[6] = ((rdata & 0x000000FF) >> 0);
   dev->buffer[7] = ((rdata & 0x0000FF00) >> 8);
-  dev->buffer[8] = ((rdata & 0x00FF0000) >> 16);
-  dev->buffer[9] = ((rdata & 0xFF000000) >> 24);
+  rdata = ioread16(dev->regs + MEM_OFFSET_DATA_ACCEL_Y);
+  dev->buffer[8] = ((rdata & 0x000000FF) >> 0);
+  dev->buffer[9] = ((rdata & 0x0000FF00) >> 8);
+  rdata = ioread16(dev->regs + MEM_OFFSET_DATA_ACCEL_Z);
+  dev->buffer[10] = ((rdata & 0x000000FF) >> 0);
+  dev->buffer[11] = ((rdata & 0x0000FF00) >> 8);
+
+  rdata = ioread16(dev->regs + MEM_OFFSET_DATA_MAG_X);
+  dev->buffer[12] = ((rdata & 0x000000FF) >> 0);
+  dev->buffer[13] = ((rdata & 0x0000FF00) >> 8);
+  rdata = ioread16(dev->regs + MEM_OFFSET_DATA_MAG_Y);
+  dev->buffer[14] = ((rdata & 0x000000FF) >> 0);
+  dev->buffer[15] = ((rdata & 0x0000FF00) >> 8);
+  rdata = ioread16(dev->regs + MEM_OFFSET_DATA_MAG_Z);
+  dev->buffer[16] = ((rdata & 0x000000FF) >> 0);
+  dev->buffer[17] = ((rdata & 0x0000FF00) >> 8);
+
+  rdata = ioread32(dev->regs + MEM_OFFSET_TIMESTAMP_LOW);
+  dev->buffer[18] = ((rdata & 0x000000FF) >> 0);
+  dev->buffer[19] = ((rdata & 0x0000FF00) >> 8);
+  dev->buffer[20] = ((rdata & 0x00FF0000) >> 16);
+  dev->buffer[21] = ((rdata & 0xFF000000) >> 24);
+
+  rdata = ioread32(dev->regs + MEM_OFFSET_TIMESTAMP_HIGH);
+  dev->buffer[22] = ((rdata & 0x000000FF) >> 0);
+  dev->buffer[23] = ((rdata & 0x0000FF00) >> 8);
+  dev->buffer[24] = ((rdata & 0x00FF0000) >> 16);
+  dev->buffer[25] = ((rdata & 0xFF000000) >> 24);
 
   /* copy data from kernel space buffer into user space */
   if (count > 0)


### PR DESCRIPTION
Add a kernel driver module that interacts with an FPGA core, which provides data from the MPU9250 Gyroscope/Accelerometer/Magnetometer sensor.