### PR TITLE
Adapt sevensegment driver and user space.

### DIFF
--- a/user/show_ip/main.cpp
+++ b/user/show_ip/main.cpp
@@ -36,6 +36,9 @@ int writeToCDev(char chars[], uint8_t brightness) {
         } else {
             values[i] = '0';
         }
+
+        // Convert to binary for driver
+        values[i] -= '0';
     }
 
     // open character device


### PR DESCRIPTION
- more generic naming scheme
- fix compatibility issue

- also adapt other drivers to be more generic in naming scheme and data buffer structure