### PR TITLE
Fix show_ip to work with updated sevensegment driver

### DIFF
--- a/user/show_ip/main.cpp
+++ b/user/show_ip/main.cpp
@@ -47,7 +47,7 @@ int writeToCDev(char chars[], uint8_t brightness) {
 
     // write display values
     for (int i = 0; i < SEGMENT_COUNT; ++i) {
-        if (fputc(values[i], fd) == EOF) {
+        if (fputc(values[i] - '0', fd) == EOF) {
             std::cerr << "Failed to write character (index " << i << ")" << std::endl;
             return -1;
         }


### PR DESCRIPTION
map characters '0'-'9' to 0x0-0x9